### PR TITLE
Extended the catValidationService to be able to set & clear specific fieldErrors

### DIFF
--- a/src/main/javascript/service/cat-validation-service.js
+++ b/src/main/javascript/service/cat-validation-service.js
@@ -32,13 +32,12 @@ function CatValidationService($log,
     var that = this;
 
     /**
-     * Adds a field error to the given fieldErrors
+     * Adds a field error to the context
      * @param fieldName name of the faulty field
      * @param errorMessage associated error message to display
      * @param context affected context
-     * @private
      */
-    var _addFieldError = function (fieldName, errorMessage, context) {
+    function appendFieldErrorToContext(fieldName, errorMessage, context) {
         if (catMessagesConfig.knownFieldsActive === true) {
             // If the error is for a known field, show the error at the field.
             // If not, display it as a global error.
@@ -54,7 +53,7 @@ function CatValidationService($log,
             context.fieldErrors[fieldName] = context.fieldErrors[fieldName] || [];
             context.fieldErrors[fieldName].push(errorMessage);
         }
-    };
+    }
 
     /**
      * Returns the validations context for a specific context identifier.
@@ -100,7 +99,7 @@ function CatValidationService($log,
     this.addFieldError = function (fieldName, errorMessage, contextId) {
         var context = that.getContext(contextId);
         context.fieldErrors = context.fieldErrors || {};
-        _addFieldError(fieldName, errorMessage, context);
+        appendFieldErrorToContext(fieldName, errorMessage, context);
     };
 
     this.updateFromRejection = function (rejection) {
@@ -130,7 +129,7 @@ function CatValidationService($log,
             // group by field
             _.forEach(rejection.data.fieldErrors, function (fieldError) {
                 // Allow config to switch between displaying errors at the field and displaying errors at known fields or globally
-                _addFieldError(fieldError.field, fieldError.message, context);
+                appendFieldErrorToContext(fieldError.field, fieldError.message, context);
             });
         }
 

--- a/src/main/javascript/service/cat-validation-service.js
+++ b/src/main/javascript/service/cat-validation-service.js
@@ -32,6 +32,31 @@ function CatValidationService($log,
     var that = this;
 
     /**
+     * Adds a field error to the given fieldErrors
+     * @param fieldName name of the faulty field
+     * @param errorMessage associated error message to display
+     * @param context affected context
+     * @private
+     */
+    var _addFieldError = function (fieldName, errorMessage, context) {
+        if (catMessagesConfig.knownFieldsActive === true) {
+            // If the error is for a known field, show the error at the field.
+            // If not, display it as a global error.
+            if (_.contains(context.knownFields, fieldName)) {
+                context.fieldErrors[fieldName] = context.fieldErrors[fieldName] || [];
+                context.fieldErrors[fieldName].push(errorMessage);
+            } else {
+                context.global = [ errorMessage ];
+                // TODO is this also context dependend? or even necessary?
+                $globalMessages.addMessages('error', context.global, context);
+            }
+        } else {
+            context.fieldErrors[fieldName] = context.fieldErrors[fieldName] || [];
+            context.fieldErrors[fieldName].push(errorMessage);
+        }
+    };
+
+    /**
      * Returns the validations context for a specific context identifier.
      * @param {string} contextId context identifier
      * @returns {ValidationContext} validation context
@@ -66,6 +91,18 @@ function CatValidationService($log,
         delete catValidationContexts[contextId];
     };
 
+    /**
+     * Adds a error message for a specific field to the context.
+     * @param fieldName name of the faulty field
+     * @param errorMessage associated error message
+     * @param contextId id of the affected context
+     */
+    this.addFieldError = function (fieldName, errorMessage, contextId) {
+        var context = that.getContext(contextId);
+        context.fieldErrors = context.fieldErrors || {};
+        _addFieldError(fieldName, errorMessage, context);
+    };
+
     this.updateFromRejection = function (rejection) {
         var contextId;
         if (!!rejection.config) {
@@ -73,8 +110,7 @@ function CatValidationService($log,
         }
 
         var context = that.getContext(contextId);
-
-        var fieldErrors = context.fieldErrors = {};
+        context.fieldErrors = {};
 
         var rejectionData = rejection.data;
         context.global = undefined;
@@ -94,20 +130,7 @@ function CatValidationService($log,
             // group by field
             _.forEach(rejection.data.fieldErrors, function (fieldError) {
                 // Allow config to switch between displaying errors at the field and displaying errors at known fields or globally
-                if (catMessagesConfig.knownFieldsActive === true) {
-                    // If the error is for a known field, show the error at the field.
-                    // If not, display it as a global error.
-                    if (_.contains(context.knownFields, fieldError.field)) {
-                        fieldErrors[fieldError.field] = fieldErrors[fieldError.field] || [];
-                        fieldErrors[fieldError.field].push(fieldError.message);
-                    } else {
-                        rejection.data.globalErrors = rejection.data.globalErrors || [];
-                        rejection.data.globalErrors.push(fieldError.message);
-                    }
-                } else {
-                    fieldErrors[fieldError.field] = fieldErrors[fieldError.field] || [];
-                    fieldErrors[fieldError.field].push(fieldError.message);
-                }
+                _addFieldError(fieldError.field, fieldError.message, context);
             });
         }
 
@@ -123,6 +146,16 @@ function CatValidationService($log,
         var context = that.getContext(contextId);
         delete context.global;
         context.fieldErrors = {};
+    };
+
+    /**
+     * Clears existing errors for the field of the specified context
+     * @param fieldName name of the field
+     * @param contextId id of the affected context
+     */
+    this.clearFieldError = function (fieldName, contextId) {
+        var context = that.getContext(contextId);
+        delete context.fieldErrors[fieldName];
     };
 
     this.hasGlobalErrors = function (contextId) {

--- a/src/test/javascript/service/cat-validation-service.spec.js
+++ b/src/test/javascript/service/cat-validation-service.spec.js
@@ -117,6 +117,34 @@ describe('CatValidationService', function () {
         expect(catValidationService.getFieldErrors('name', contextId)).toBeDefined();
     });
 
+    it('should handle specific field errors', function() {
+        var contextId = catValidationService.createContext();
+
+        catValidationService.addFieldError('file', 'exceeded allowed file size', contextId);
+        expect(catValidationService.hasGlobalErrors()).toBe(false);
+        expect(catValidationService.hasGlobalErrors(contextId)).toBe(false);
+        expect(catValidationService.hasFieldErrors('file')).toBe(false);
+        expect(catValidationService.getFieldErrors('file')).toBeUndefined();
+        expect(catValidationService.hasFieldErrors('file', contextId)).toBe(true);
+        expect(catValidationService.getFieldErrors('file', contextId)).toBeDefined();
+    });
+
+    it('should handle specific field errors without context', function() {
+        catValidationService.addFieldError('file', 'exceeded allowed file size');
+        expect(catValidationService.hasGlobalErrors()).toBe(false);
+        expect(catValidationService.hasFieldErrors('file')).toBe(true);
+        expect(catValidationService.getFieldErrors('file')).toBeDefined();
+    });
+
+    it('should clear specific field errors', function() {
+        var contextId = catValidationService.createContext();
+
+        catValidationService.addFieldError('file', 'exceeded allowed file size', contextId);
+        expect(catValidationService.hasFieldErrors('file', contextId)).toBe(true);
+        catValidationService.clearFieldError('file', contextId);
+        expect(catValidationService.hasFieldErrors('file', contextId)).toBe(false);
+    });
+
     describe('with knownFieldsActive flag', function () {
 
         beforeEach(function () {


### PR DESCRIPTION
Currently the catValidationService is used by calling the "updateFromRejection" function from within the httpInterceptor.

This solution does only work, if the frontend receives a faulty message from the backend. 
But if there is some frontend-validation going on, i want to be able to set specific error messages for some specific fields without the need to hit the backend with faulty data.

So i implemented basically 2 functions - one for creating a specific field error and one for clearing errors of a specific field. 